### PR TITLE
Force last compatibility for IE

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -9,6 +9,7 @@
 
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
 		<?php
 		wp_print_styles( array( 'presenter', 'reveal', 'reveal-theme', 'reveal-lib-zenburn' ) );


### PR DESCRIPTION
IE (tested with IE11), by default, will use the compatibility mode IE5 (~o~)
Added meta tag for edge compatibility.
